### PR TITLE
added estimator_type property

### DIFF
--- a/tpot2/tpot_estimator/estimator.py
+++ b/tpot2/tpot_estimator/estimator.py
@@ -933,6 +933,11 @@ class TPOTEstimator(BaseEstimator):
     def classes_(self):
         """The classes labels. Only exist if the last step is a classifier."""
         return self.fitted_pipeline_.classes_
+    
+
+    @property
+    def _estimator_type(self):
+        return self.fitted_pipeline_._estimator_type
 
 
     def make_evaluated_individuals(self):

--- a/tpot2/tpot_estimator/steady_state_estimator.py
+++ b/tpot2/tpot_estimator/steady_state_estimator.py
@@ -917,6 +917,9 @@ class TPOTEstimatorSteadyState(BaseEstimator):
         """The classes labels. Only exist if the last step is a classifier."""
         return self.fitted_pipeline_.classes_
 
+    @property
+    def _estimator_type(self):
+        return self.fitted_pipeline_._estimator_type
 
     def make_evaluated_individuals(self):
         #check if _evolver_instance exists


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

adds a _estimator_type property to both tpotestimators to make it consistent with other sklearn estimators.

    @property
    def _estimator_type(self):
        return self.fitted_pipeline_._estimator_type

## Any background context you want to provide?


After the new autosklearn update, this property used by some scorers to determine whether the pipeline was a classifier or regressor. These scorers would throw an error when used with either tpotestimators. 
