### PR TITLE
Update docs/requirements_docs.txt to latest versions

### DIFF
--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,7 +1,7 @@
-mkdocs==1.4.2
-mkdocs-material==9.1.6
-mkdocs-include-markdown-plugin==4.0.4
+mkdocs==1.5.2
+mkdocs-material==9.2.5
+mkdocs-include-markdown-plugin==6.0.0
 nbconvert==7.7.4
-mkdocs-jupyter==0.24.1
-mkdocstrings==0.21.2
-mkdocstrings-python==0.10.1
+mkdocs-jupyter==0.24.2
+mkdocstrings==0.22.0
+mkdocstrings-python==1.6.0


### PR DESCRIPTION
## What does this PR do?
Update requirements_docs.txt to latest versions of dependencies

## Where should the reviewer start?
The doc builder github action is failing with this error:
`ERROR    -  Error reading page 'documentation/tpot2/graphsklearn.md': maximum recursion depth exceeded in comparison.`
Incompatible mkdocs dependencies are causing this problem. This PR updates all dependencies and now the docs will build without errors.

## How should this PR be tested?
to try this out locally, in a virtualenv run:
`pip install docs/requirements_docs.txt`
`mkdocs --verbose --clean`
documentation should be built successfully.

## What are the relevant issues?
The latest error on doc builds is here: https://github.com/EpistasisLab/tpot2/actions/runs/5969392714/job/16195176147

## Screenshots (if appropriate)
![image](https://github.com/EpistasisLab/tpot2/assets/20008149/7ed96904-72e3-4ff9-902b-c30e33043dfe)
