### PR TITLE
Dev

### DIFF
--- a/tpot2/evolvers/base_evolver.py
+++ b/tpot2/evolvers/base_evolver.py
@@ -494,7 +494,6 @@ class BaseEvolver():
             else:
                 self.cur_population_size = self.population_size
 
-                
         if self.budget_list is not None:
             if len(self.budget_list) <= self.generation:
                 self.budget = self.budget_range[-1]
@@ -502,7 +501,6 @@ class BaseEvolver():
                 self.budget = self.budget_list[self.generation]
         else:
             self.budget = None
-
 
         if self.survival_selector is not None:
             n_survivors = max(1,int(self.cur_population_size*self.survival_percentage)) #always keep at least one individual
@@ -512,15 +510,12 @@ class BaseEvolver():
                                                 n_survivors=n_survivors, 
                                                 inplace=True)
             
-
         self.generate_offspring()
         self.evaluate_population()
 
         self.generation += 1
         
     def generate_offspring(self, ): #your EA Algorithm goes here
-        
-
         n_mutations = np.random.binomial(self.cur_population_size, self.mutate_probability)
         n_crossover = self.cur_population_size - n_mutations
         
@@ -533,7 +528,6 @@ class BaseEvolver():
         var_op_list = np.concatenate([var_op_list, ["mutate"]*n_mutations])
 
         parents = list(cx_parents) + list(m_parents)
-
 
         offspring = self.population.create_offspring2(parents, var_op_list, self.mutation_functions, self.mutation_function_weights, self.crossover_functions, self.crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True) 
         

--- a/tpot2/evolvers/base_evolver.py
+++ b/tpot2/evolvers/base_evolver.py
@@ -627,7 +627,7 @@ class BaseEvolver():
         if budget is not None:
             self.population.update_column(individuals_to_evaluate, column_names="Budget", data=budget)
 
-        self.population.update_column(individuals_to_evaluate, column_names="Completed Timestamp", data=start_times)
+        self.population.update_column(individuals_to_evaluate, column_names="Submitted Timestamp", data=start_times)
         self.population.update_column(individuals_to_evaluate, column_names="Completed Timestamp", data=end_times)
         self.population.remove_invalid_from_population(column_names=self.objective_names)
         self.population.remove_invalid_from_population(column_names=self.objective_names, invalid_value="TIMEOUT")
@@ -692,21 +692,22 @@ class BaseEvolver():
             if parallel_timeout < 0:
                 parallel_timeout = 10
 
-            scores = tpot2.utils.eval_utils.parallel_eval_objective_list(individual_list=unevaluated_individuals_this_step,
+            scores, start_times, end_times = tpot2.utils.eval_utils.parallel_eval_objective_list2(individual_list=unevaluated_individuals_this_step,
                                     objective_list=self.objective_functions,
-                                    n_jobs = self.n_jobs,
                                     verbose=self.verbose,
-                                    timeout=self.max_eval_time_seconds,
+                                    max_eval_time_seconds=self.max_eval_time_seconds,
                                     step=step,
                                     budget = self.budget,
                                     generation = self.generation,
                                     n_expected_columns=len(self.objective_names),
                                     client=self._client,
-                                    parallel_timeout=parallel_timeout,
                                     **self.objective_kwargs,
                                     )
 
             self.population.update_column(unevaluated_individuals_this_step, column_names=this_step_names, data=scores)
+            self.population.update_column(unevaluated_individuals_this_step, column_names="Submitted Timestamp", data=start_times)
+            self.population.update_column(unevaluated_individuals_this_step, column_names="Completed Timestamp", data=end_times)
+
 
             self.population.remove_invalid_from_population(column_names=this_step_names)
             self.population.remove_invalid_from_population(column_names=this_step_names, invalid_value="TIMEOUT")

--- a/tpot2/evolvers/steady_state_evolver.py
+++ b/tpot2/evolvers/steady_state_evolver.py
@@ -279,7 +279,7 @@ class SteadyStateEvolver():
                     else: #if future is not done
                         
                         #check if the future has been running for too long, cancel the future
-                        if time.time() - submitted_futures[completed_future]["time"] > self.max_eval_time_seconds*2:
+                        if time.time() - submitted_futures[completed_future]["time"] > self.max_eval_time_seconds*1.25:
                             completed_future.cancel()
                             
                             if self.verbose >= 4:

--- a/tpot2/population.py
+++ b/tpot2/population.py
@@ -86,7 +86,21 @@ class Population():
         self.callback=callback
         self.population = []
 
+    def survival_select(self, selector, weights, columns_names, n_survivors, inplace=True):
+        weighted_scores = self.get_column(self.population, column_names=columns_names) * weights
+        new_population_index = np.ravel(selector(weighted_scores, k=n_survivors)) #TODO make it clear that we are concatenating scores...
+        new_population = np.array(self.population)[new_population_index]
+        if inplace:
+            self.set_population(new_population)
+        return new_population
 
+    def parent_select(self, selector, weights, columns_names, k, n_parents):
+
+        weighted_scores = self.get_column(self.population, column_names=columns_names) * weights
+        parents_index = selector(weighted_scores, k=k, n_parents=n_parents)
+        parents = np.array(self.population)[parents_index]
+        return parents
+    
 
     #remove individuals that either do not have a column_name value or a nan in that value
     #TODO take into account when the value is not a list/tuple?
@@ -294,7 +308,111 @@ class Population():
             
         return new_offspring
 
-   
+    def parent_select_and_create_offspring(self,selector, n, mutation_probability,crossover_probability, mutate_then_crossover_probability, crossover_then_mutate_probability,  weights, columns_names, mutation_functions,mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True):
+        n_mutations = np.random.binomial(n, mutation_probability)
+        n_crossover = n - n_mutations
+        
+        cx_parents = self.parent_select(selector=selector, weights=weights, columns_names=columns_names, k=n_crossover, n_parents=2)
+        m_parents = self.parent_select(selector=selector, weights=weights, columns_names=columns_names, k=n_mutations, n_parents=1)
+
+        p = np.array([crossover_probability, mutate_then_crossover_probability, crossover_then_mutate_probability])
+        p = p/np.sum(p)
+        var_op_list = np.random.choice(["crossover", "mutate_then_crossover", "crossover_then_mutate"], size=n_crossover, p=p)
+        var_op_list = np.concatenate([var_op_list, ["mutate"]*n_mutations])
+
+        parents = list(cx_parents) + list(m_parents)
+
+        offspring = self.create_offspring2(parents, var_op_list, mutation_functions, mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=add_to_population, keep_repeats=keep_repeats, mutate_until_unique=mutate_until_unique) 
+
+        return offspring
+
+    #TODO should we just generate one offspring per crossover? 
+    def create_offspring2(self, parents_list, var_op_list, mutation_functions,mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True):
+        '''
+        parents_list: a list of lists of parents. 
+        var_op_list: a list of var_ops to apply to each list of parents. Should be the same length as parents_list.
+
+        for example:
+        parents_list = [[parent1, parent2], [parent3]]
+        var_op_list = ["crossover", "mutate"]
+
+        This will apply crossover to parent1 and parent2 and mutate to parent3.
+
+        Creates offspring from parents using the var_op_list.
+        If string, will use a built in method 
+            - "crossover" : crossover
+            - "mutate" : mutate
+            - "mutate_and_crossover" : mutate_and_crossover
+            - "cross_and_mutate" : cross_and_mutate
+        '''
+        new_offspring = []
+
+        all_offspring = []
+        chosen_ops = []
+
+        for parents, var_op in zip(parents_list,var_op_list):
+            #TODO put this loop in population class
+            if var_op == "mutation":
+                mutation_op = np.random.choice(mutation_functions, p=mutation_function_weights)
+                all_offspring.append(copy_and_mutate(parents, mutation_op))
+                chosen_ops.append(mutation_op.__name__)
+            
+            
+            elif var_op == "crossover":
+                crossover_op = np.random.choice(crossover_functions, p=crossover_function_weights)
+                all_offspring.append(copy_and_crossover(parents, crossover_op))
+                chosen_ops.append(crossover_op.__name__)
+            elif var_op == "mutate_then_crossover":
+
+                mutation_op1 = np.random.choice(mutation_functions, p=mutation_function_weights)
+                mutation_op2 = np.random.choice(mutation_functions, p=mutation_function_weights)
+                crossover_op = np.random.choice(crossover_functions, p=crossover_function_weights)
+                p1 = copy_and_mutate(parents[0], mutation_op1)
+                p2 = copy_and_mutate(parents[1], mutation_op2)
+                crossover_op(p1,p2)
+                all_offspring.append(p1)
+                chosen_ops.append(f"{mutation_op1.__name__} , {mutation_op2.__name__} , {crossover_op.__name__}")
+            elif var_op == "crossover_then_mutate":
+                crossover_op = np.random.choice(crossover_functions, p=crossover_function_weights)
+                child = copy_and_crossover(parents, crossover_op)
+                mutation_op = np.random.choice(mutation_functions, p=mutation_function_weights)
+                mutation_op(child)
+                all_offspring.append(child)
+                chosen_ops.append(f"{crossover_op.__name__} , {mutation_op.__name__}")
+
+
+        for parents, offspring, var_op in zip(parents_list, all_offspring, chosen_ops):
+            
+            # if var_op in built_in_var_ops_dict:
+            #     var_op = built_in_var_ops_dict[var_op]
+
+            # offspring = copy.deepcopy(parents)
+            # offspring = var_op(offspring)
+            # if isinstance(offspring, collections.abc.Iterable):
+            #     offspring = offspring[0] 
+
+            if add_to_population:
+                added = self.add_to_population(offspring, keep_repeats=keep_repeats, mutate_until_unique=mutate_until_unique)
+                if len(added) > 0:
+                    for new_child in added:
+                        parent_keys = [parent.unique_id() for parent in parents]
+                        if not pd.api.types.is_object_dtype(self.evaluated_individuals["Parents"]): #TODO Is there a cleaner way of doing this? Not required for some python environments?
+                            self.evaluated_individuals["Parents"] = self.evaluated_individuals["Parents"].astype('object')
+                        self.evaluated_individuals.at[new_child.unique_id(),"Parents"] = tuple(parent_keys)
+                        
+                        self.evaluated_individuals.at[new_child.unique_id(),"Variation_Function"] = var_op
+                        
+                        
+                        new_offspring.append(new_child)
+
+            else:
+                new_offspring.append(offspring)
+                            
+            
+        return new_offspring
+
+
+
 
 def get_id(individual):
     return individual.unique_id()
@@ -325,6 +443,8 @@ def nonparallel_create_offpring(parents_list, var_op_list, n_jobs=1):
     return offspring
 
 
+
+
 def copy_and_change(parents, var_op):
     offspring = copy.deepcopy(parents)
     offspring = var_op(offspring)
@@ -332,6 +452,19 @@ def copy_and_change(parents, var_op):
         offspring = offspring[0]
     return offspring
 
+def copy_and_mutate(parents, var_op):
+    offspring = copy.deepcopy(parents)
+    var_op(offspring)
+    if isinstance(offspring, collections.abc.Iterable):
+        offspring = offspring[0]
+    return offspring
+
+def copy_and_crossover(parents, var_op):
+    offspring = copy.deepcopy(parents)
+    var_op(offspring[0],offspring[1])
+    return offspring[0]
+
 def parallel_get_id(n_jobs, individual_list):
     id_list = Parallel(n_jobs=n_jobs)(delayed(get_id)(ind)  for ind in individual_list)
     return id_list
+

--- a/tpot2/population.py
+++ b/tpot2/population.py
@@ -308,23 +308,6 @@ class Population():
             
         return new_offspring
 
-    def parent_select_and_create_offspring(self,selector, n, mutation_probability,crossover_probability, mutate_then_crossover_probability, crossover_then_mutate_probability,  weights, columns_names, mutation_functions,mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True):
-        n_mutations = np.random.binomial(n, mutation_probability)
-        n_crossover = n - n_mutations
-        
-        cx_parents = self.parent_select(selector=selector, weights=weights, columns_names=columns_names, k=n_crossover, n_parents=2)
-        m_parents = self.parent_select(selector=selector, weights=weights, columns_names=columns_names, k=n_mutations, n_parents=1)
-
-        p = np.array([crossover_probability, mutate_then_crossover_probability, crossover_then_mutate_probability])
-        p = p/np.sum(p)
-        var_op_list = np.random.choice(["crossover", "mutate_then_crossover", "crossover_then_mutate"], size=n_crossover, p=p)
-        var_op_list = np.concatenate([var_op_list, ["mutate"]*n_mutations])
-
-        parents = list(cx_parents) + list(m_parents)
-
-        offspring = self.create_offspring2(parents, var_op_list, mutation_functions, mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=add_to_population, keep_repeats=keep_repeats, mutate_until_unique=mutate_until_unique) 
-
-        return offspring
 
     #TODO should we just generate one offspring per crossover? 
     def create_offspring2(self, parents_list, var_op_list, mutation_functions,mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True):

--- a/tpot2/population.py
+++ b/tpot2/population.py
@@ -328,23 +328,7 @@ class Population():
 
     #TODO should we just generate one offspring per crossover? 
     def create_offspring2(self, parents_list, var_op_list, mutation_functions,mutation_function_weights, crossover_functions,crossover_function_weights, add_to_population=True, keep_repeats=False, mutate_until_unique=True):
-        '''
-        parents_list: a list of lists of parents. 
-        var_op_list: a list of var_ops to apply to each list of parents. Should be the same length as parents_list.
 
-        for example:
-        parents_list = [[parent1, parent2], [parent3]]
-        var_op_list = ["crossover", "mutate"]
-
-        This will apply crossover to parent1 and parent2 and mutate to parent3.
-
-        Creates offspring from parents using the var_op_list.
-        If string, will use a built in method 
-            - "crossover" : crossover
-            - "mutate" : mutate
-            - "mutate_and_crossover" : mutate_and_crossover
-            - "cross_and_mutate" : cross_and_mutate
-        '''
         new_offspring = []
 
         all_offspring = []

--- a/tpot2/tpot_estimator/steady_state_estimator.py
+++ b/tpot2/tpot_estimator/steady_state_estimator.py
@@ -59,7 +59,7 @@ class TPOTEstimatorSteadyState(BaseEstimator):
                         early_stop_seconds = None,
                         scorers_early_stop_tol = 0.001,
                         other_objectives_early_stop_tol = None,
-                        max_time_seconds=float('inf'), 
+                        max_time_seconds=None, 
                         max_eval_time_seconds=60*10, 
                         n_jobs=1,
                         memory_limit = "4GB",


### PR DESCRIPTION
I updated the BaseEvolver to try to address some of the concerns. This is on my personal fork.

Probabilities for mutation/cx are now sampled one by one rather than fixed frequencies.

slight reorganization to step() and one_generation_step(). I moved survival selection and eval to step(), removed one_generation_step(), and added generate_offspring(). generate_offspring() was made to address Jose's request of a "lambda" function. So this is a simple single place to modify the code to change how offspring are created.

I chose not to make this a standalone function because it would then complicate code for end users. parameters for this function would have to be either passed separately into an obscure dictionary parameter, or users would have to create a partial/lambda function. Additionally this way makes it easier to log things like parents and specific mutation/cx methods used in generation. 

population class now has a function do survival selection and parent selection that return a list of individuals so users do not have to deal with scores/weights directly, slightly simplifies the code for the user at the evolver level.

we can now pass in individual mutation and crossover functions and their weights. (though the graphindividual is not set up this way and would need to be modified to take advantage of this)

I kept support for mutate then crossover and crossover then mutate. Should we keep this or remove? Makes a code a bit clunky. 


Other changes:

I also updated the parallel eval function for base evolver. It uses a more advanced dask setup that manually keeps track of futures so that we can correctly timeout individual runs (rather than timing out the entire generation), and keep track of start and end times per pipeline. (basically the same way that the steady state evolver keeps track of parallelization). I also reduced the fallback timeout to 1.25 x max_eval_time_seconds from 2x. 

Also a fix to make jupyter notebooks work on the github page. Basically I had to remove the markdown syntax (which worked correctly on my machine) since the github repo uses an old buggy version of nbconvert. 


I have not changed the steady state code. The population selection functions assume that the live population are fully evaluated. I mentioned this before, but we could change the population class to two lists, one for evaluated parents and one for unevaluated offspring. Currently both are in the same list in the population class.