### PR TITLE
fix to allow mutations to actually occur to an individual

### DIFF
--- a/tpot2/population.py
+++ b/tpot2/population.py
@@ -330,9 +330,9 @@ class Population():
 
         for parents, var_op in zip(parents_list,var_op_list):
             #TODO put this loop in population class
-            if var_op == "mutation":
+            if var_op == "mutate":
                 mutation_op = rng.choice(mutation_functions, p=mutation_function_weights)
-                all_offspring.append(copy_and_mutate(parents, mutation_op, rng_=rng))
+                all_offspring.append(copy_and_mutate(parents[0], mutation_op, rng_=rng))
                 chosen_ops.append(mutation_op.__name__)
 
 


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

When experimenting with TPOT2 and only allowing mutations to occur, no variation would be applied to the parents. This is because the `var_op` was 'mutate', not 'mutation'. Additionally, we needed to send an individual to the `copy_and_mutate` function, not a numpy array. This fix does all that. 

## Where should the reviewer start?

`tpot2/population.py `-> `create_offspring2()`

## How should this PR be tested?



## Any background context you want to provide?



## What are the relevant issues?

[you can link directly to issues by entering # then the number of the issue]

## Screenshots (if appropriate)



## Questions:

- Do the docs need to be updated?
- Does this PR add new (Python) dependencies?
