### PR TITLE
fixed recursive search space probabilities

### DIFF
--- a/tpot2/individual_representations/graph_pipeline_individual/individual.py
+++ b/tpot2/individual_representations/graph_pipeline_individual/individual.py
@@ -1193,7 +1193,10 @@ def random_weighted_sort(l,weights, rng_=None):
     sorted_l = []
     indeces = {i: weights[i] for i in range(len(l))}
     while len(indeces) > 0:
-        next_item = rng.choice(list(indeces.keys()), p=list(indeces.values()))
+        keys = list(indeces.keys())
+        p = np.array([indeces[k] for k in keys])
+        p = p / p.sum()
+        next_item = rng.choice(list(indeces.keys()), p=p)
         indeces.pop(next_item)
         sorted_l.append(l[next_item])
 


### PR DESCRIPTION
The random_weighted_sort function was broken due to the current random generator function requiring weights to sum to 1. This change fixes the function by ensuring that weights are normalized to sum to 1 during each loop.


This function is used in determining recursive search space mutation/crossover probabilities. This bug prevented those from being used.