### PR TITLE
fixed config dict typo

### DIFF
--- a/tpot2/tpot_estimator/estimator_utils.py
+++ b/tpot2/tpot_estimator/estimator_utils.py
@@ -79,7 +79,7 @@ def get_configuration_dictionary(options, n_samples, n_features, classification,
 
 
         else:
-            config_dict.update(recursive_with_defaults(options, n_samples, n_features, classification, random_state, cv, subsets=subsets, feature_names=feature_names, n_classes=n_classes))
+            config_dict.update(recursive_with_defaults(option, n_samples, n_features, classification, random_state, cv, subsets=subsets, feature_names=feature_names, n_classes=n_classes))
 
     if len(config_dict) == 0:
         raise ValueError("No valid configuration options were provided. Please check the options you provided and try again.")


### PR DESCRIPTION
A typo was introduced in #106 in line 82 of the get_configuration_dictionary function. The variable 'option' was incorrectly changed to 'options'.  I reverted this change back to the correct variable.