### PR TITLE
allow genetic feature selection to work with nan values

### DIFF
--- a/tpot2/builtin_modules/feature_set_selector.py
+++ b/tpot2/builtin_modules/feature_set_selector.py
@@ -92,6 +92,9 @@ class FeatureSetSelector(BaseEstimator, SelectorMixin):
 
     # def transform(self, X):
     
+    def _get_tags(self):
+        tags = {"allow_nan": True, "requires_y": False}
+        return tags
 
     def _get_support_mask(self):
         """

--- a/tpot2/search_spaces/nodes/genetic_feature_selection.py
+++ b/tpot2/search_spaces/nodes/genetic_feature_selection.py
@@ -19,6 +19,11 @@ class MaskSelector(BaseEstimator, SelectorMixin):
         self.mask = mask
 
     def fit(self, X, y=None):
+        self.n_features_in_ = X.shape[1]
+        if isinstance(X, pd.DataFrame):
+            self.feature_names_in_ = X.columns
+        #     self.set_output(transform="pandas")
+        self.is_fitted_ = True #so sklearn knows it's fitted
         return self
 
     def _get_tags(self):
@@ -28,6 +33,8 @@ class MaskSelector(BaseEstimator, SelectorMixin):
     def _get_support_mask(self):
         return np.array(self.mask)
 
+    def get_feature_names_out(self, input_features=None):
+        return self.feature_names_in_[self.get_support()]
 
 class GeneticFeatureSelectorIndividual(SklearnIndividual):
     def __init__(   self,

--- a/tpot2/search_spaces/nodes/genetic_feature_selection.py
+++ b/tpot2/search_spaces/nodes/genetic_feature_selection.py
@@ -15,8 +15,11 @@ from ..base import SklearnIndividual, SklearnIndividualGenerator
 class MaskSelector(BaseEstimator, SelectorMixin):
     """Select predefined feature subsets."""
 
-    def __init__(self, mask):
+    def __init__(self, mask, set_output_transform=None):
         self.mask = mask
+        self.set_output_transform = set_output_transform
+        if set_output_transform is not None:
+            self.set_output(transform=set_output_transform)
 
     def fit(self, X, y=None):
         self.n_features_in_ = X.shape[1]

--- a/tpot2/search_spaces/nodes/genetic_feature_selection.py
+++ b/tpot2/search_spaces/nodes/genetic_feature_selection.py
@@ -21,6 +21,10 @@ class MaskSelector(BaseEstimator, SelectorMixin):
     def fit(self, X, y=None):
         return self
 
+    def _get_tags(self):
+        tags = {"allow_nan": True, "requires_y": False}
+        return tags
+
     def _get_support_mask(self):
         return np.array(self.mask)
 


### PR DESCRIPTION
added a tag so that the MaskSelector used in genetic feature selection can work on datasets with nans. Previously sklearn throws an error by default when calling transform if the data have nans. 