### PR TITLE
edit sort and loop for fitted pipeline

### DIFF
--- a/tpot2/tpot_estimator/steady_state_estimator.py
+++ b/tpot2/tpot_estimator/steady_state_estimator.py
@@ -879,29 +879,40 @@ class TPOTEstimatorSteadyState(BaseEstimator):
         else:
             self.objective_names_for_selection = self.objective_names
 
-        val_scores = self.evaluated_individuals[~self.evaluated_individuals[self.objective_names_for_selection].isin(["TIMEOUT","INVALID"]).any(axis=1)][self.objective_names_for_selection].astype(float)
+        val_scores = self.evaluated_individuals[self.evaluated_individuals[self.objective_names_for_selection].isin(["TIMEOUT","INVALID"]).any(axis=1).ne(True)][self.objective_names_for_selection].astype(float)
         weighted_scores = val_scores*self.objective_function_weights
 
         if self.bigger_is_better:
-            best_idx = weighted_scores[self.objective_names_for_selection[0]].idxmax()
+            best_indices = list(weighted_scores.sort_values(by=self.objective_names_for_selection, ascending=False).index)
         else:
-            best_idx = weighted_scores[self.objective_names_for_selection[0]].idxmin()
+            best_indices = list(weighted_scores.sort_values(by=self.objective_names_for_selection, ascending=True).index)
 
-        best_individual = self.evaluated_individuals.loc[best_idx]['Individual']
-        self.selected_best_score =  self.evaluated_individuals.loc[best_idx]
+        for best_idx in best_indices:
+
+            best_individual = self.evaluated_individuals.loc[best_idx]['Individual']
+            self.selected_best_score =  self.evaluated_individuals.loc[best_idx]
 
 
-        if self.export_graphpipeline:
-            best_individual_pipeline = best_individual.export_flattened_graphpipeline(memory=self.memory)
-        else:
-            best_individual_pipeline = best_individual.export_pipeline(memory=self.memory)
+            #TODO
+            #best_individual_pipeline = best_individual.export_pipeline(memory=self.memory, cross_val_predict_cv=self.cross_val_predict_cv)
+            if self.export_graphpipeline:
+                best_individual_pipeline = best_individual.export_flattened_graphpipeline(memory=self.memory)
+            else:
+                best_individual_pipeline = best_individual.export_pipeline(memory=self.memory)
 
-        if self.preprocessing:
-            self.fitted_pipeline_ = sklearn.pipeline.make_pipeline(sklearn.base.clone(self._preprocessing_pipeline), best_individual_pipeline )
-        else:
-            self.fitted_pipeline_ = best_individual_pipeline
+            if self.preprocessing:
+                self.fitted_pipeline_ = sklearn.pipeline.make_pipeline(sklearn.base.clone(self._preprocessing_pipeline), best_individual_pipeline )
+            else:
+                self.fitted_pipeline_ = best_individual_pipeline
 
-        self.fitted_pipeline_.fit(X_original,y_original) #TODO use y_original as well?
+            try:
+                self.fitted_pipeline_.fit(X_original,y_original) #TODO use y_original as well?
+                break
+            except Exception as e:
+                if self.verbose >= 4:
+                    warnings.warn("Final pipeline failed to fit. Rarely, the pipeline might work on the objective function but fail on the full dataset. Generally due to interactions with different features being selected or transformations having different properties. Trying next pipeline")
+                    print(e)
+                continue
 
 
         if self.client is None: #no client was passed in


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Previously, the best fitted pipeline was selected by identifying a single pipeline with the max of the first objective function. If that pipeline failed, TPOT crashes without fitted_estimator_

Two changes

a) Pipelines are now sorted with all objective functions, in order. Now when multiple pipeline have the same score, they are also sorted by the second score, and so on. Previously, a random pipeline with the best score was selected, which may not have been the optimal pipeline given the other scores.

b) There is a very rare but not impossible chance that a pipeline will work correctly on in the objective functions, but fail on the full dataset. For example, a selector function that happens to select only positive values during when evaluated on the cv folds, might then select a different column that does include negative values when trained on the full dataset. If the final estimator is MultinomialNB, this will execute correctly on the objective function, but throw an error on the full dataset as it cannot accept negative values. This could cause TPOT to crash

To resolve this, TPOT will now loop through the best pipelines. If a pipeline fails, it will catch the error and try the next best pipeline. This prevents a terminal error from occurring. 

## Where should the reviewer start?
## How should this PR be tested?

Double check that the sort order is correct and it runs without issue on test data. 