### PR TITLE
Freemem

### DIFF
--- a/tpot2/evolvers/steady_state_evolver.py
+++ b/tpot2/evolvers/steady_state_evolver.py
@@ -508,7 +508,7 @@ class SteadyStateEvolver():
                 self.population.remove_invalid_from_population(column_names="Eval Error", invalid_value="TIMEOUT")
 
                 #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-                # client.run(gc.collect) #run garbage collection to free up memory
+                client.run(gc.collect) #run garbage collection to free up memory
 
                 ###############################
                 # Step 2: Early Stopping
@@ -723,7 +723,7 @@ class SteadyStateEvolver():
             future.release() #release the future
 
         #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-        # client.run(gc.collect) #run garbage collection to free up memory
+        client.run(gc.collect) #run garbage collection to free up memory
 
         #checkpoint
         if self.population_file is not None:

--- a/tpot2/evolvers/steady_state_evolver.py
+++ b/tpot2/evolvers/steady_state_evolver.py
@@ -466,13 +466,14 @@ class SteadyStateEvolver():
                                 print("cancelld ", completed_future.cancelled())
                                 scores = [np.nan for _ in range(len(self.objective_names))]
                                 eval_error = "INVALID"
+                        completed_future.release() #release the future
                     else: #if future is not done
 
                         if self.max_eval_time_mins is not None:
                             #check if the future has been running for too long, cancel the future
                             if time.time() - submitted_futures[completed_future]["time"] > self.max_eval_time_mins*1.25*60:
                                 completed_future.cancel()
-
+                                completed_future.release() #release the future
                                 if self.verbose >= 4:
                                     print(f'WARNING AN INDIVIDUAL TIMED OUT (Fallback): \n {submitted_futures[completed_future]} \n')
 
@@ -506,6 +507,8 @@ class SteadyStateEvolver():
                 self.population.remove_invalid_from_population(column_names="Eval Error", invalid_value="INVALID")
                 self.population.remove_invalid_from_population(column_names="Eval Error", invalid_value="TIMEOUT")
 
+                #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
+                # client.run(gc.collect) #run garbage collection to free up memory
 
                 ###############################
                 # Step 2: Early Stopping
@@ -717,6 +720,10 @@ class SteadyStateEvolver():
         #done, cleanup futures
         for future in submitted_futures.keys():
             future.cancel()
+            future.release() #release the future
+
+        #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
+        # client.run(gc.collect) #run garbage collection to free up memory
 
         #checkpoint
         if self.population_file is not None:

--- a/tpot2/evolvers/steady_state_evolver.py
+++ b/tpot2/evolvers/steady_state_evolver.py
@@ -444,6 +444,7 @@ class SteadyStateEvolver():
                             print("Cancelled future (likely memory related)")
                             scores = [np.nan for _ in range(len(self.objective_names))]
                             eval_error = "INVALID"
+                            client.run(gc.collect)
                         else: #if the future is done and did not throw an error, get the scores
                             try:
                                 scores = completed_future.result()

--- a/tpot2/evolvers/steady_state_evolver.py
+++ b/tpot2/evolvers/steady_state_evolver.py
@@ -508,7 +508,7 @@ class SteadyStateEvolver():
                 self.population.remove_invalid_from_population(column_names="Eval Error", invalid_value="TIMEOUT")
 
                 #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-                client.run(gc.collect) #run garbage collection to free up memory
+                #client.run(gc.collect) #run garbage collection to free up memory
 
                 ###############################
                 # Step 2: Early Stopping
@@ -723,7 +723,7 @@ class SteadyStateEvolver():
             future.release() #release the future
 
         #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-        client.run(gc.collect) #run garbage collection to free up memory
+        #client.run(gc.collect) #run garbage collection to free up memory
 
         #checkpoint
         if self.population_file is not None:

--- a/tpot2/utils/eval_utils.py
+++ b/tpot2/utils/eval_utils.py
@@ -164,6 +164,7 @@ def parallel_eval_objective_list(individual_list,
                     print("Cancelled future (likely memory related)")
                     scores = [np.nan for _ in range(n_expected_columns)]
                     eval_error = "INVALID"
+                    client.run(gc.collect)
                 else: #if the future is done and did not throw an error, get the scores
                     try:
                         scores = completed_future.result()

--- a/tpot2/utils/eval_utils.py
+++ b/tpot2/utils/eval_utils.py
@@ -228,7 +228,7 @@ def parallel_eval_objective_list(individual_list,
         
 
         #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-        client.run(gc.collect) #run garbage collection to free up memory
+        #client.run(gc.collect) #run garbage collection to free up memory
 
         #break if timeout
         if global_timeout_triggered:
@@ -252,7 +252,7 @@ def parallel_eval_objective_list(individual_list,
             submitted_inds.add(individual.unique_id())
 
     #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-    client.run(gc.collect) #run garbage collection to free up memory
+    #client.run(gc.collect) #run garbage collection to free up memory
 
     #collect remaining futures
     final_scores = [scores_dict[individual]["scores"] for individual in individual_list]

--- a/tpot2/utils/eval_utils.py
+++ b/tpot2/utils/eval_utils.py
@@ -49,6 +49,7 @@ from tqdm.dask import TqdmCallback
 from dask.distributed import progress
 import distributed
 import func_timeout
+import gc
 
 def process_scores(scores, n):
     '''
@@ -186,13 +187,15 @@ def parallel_eval_objective_list(individual_list,
                         print("cancelld ", completed_future.cancelled())
                         scores = [np.nan for _ in range(n_expected_columns)]
                         eval_error = "INVALID"
+            
+                completed_future.release() #release the future
             else: #if future is not done
 
                 # check if the future has been running for too long, cancel the future
                 # we multiply max_eval_time_mins by 1.25 since the objective function in the future should be able to cancel itself. This is a backup in case it doesn't.
                 if max_eval_time_mins is not None and time.time() - submitted_futures[completed_future]["time"] > max_eval_time_mins*1.25*60:
                     completed_future.cancel()
-                    
+                    completed_future.release()
                     if verbose >= 4:
                         print(f'WARNING AN INDIVIDUAL TIMED OUT (Fallback): \n {submitted_futures[completed_future]} \n')
                     
@@ -200,6 +203,7 @@ def parallel_eval_objective_list(individual_list,
                     eval_error = "TIMEOUT"
                 elif global_timeout_triggered:
                     completed_future.cancel()
+                    completed_future.release()
                     
                     if verbose >= 4:
                         print(f'WARNING AN INDIVIDUAL TIMED OUT (max_time_mins): \n {submitted_futures[completed_future]} \n')
@@ -222,6 +226,10 @@ def parallel_eval_objective_list(individual_list,
             #update submitted futures
             submitted_futures.pop(completed_future)
         
+
+        #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
+        # client.run(gc.collect) #run garbage collection to free up memory
+
         #break if timeout
         if global_timeout_triggered:
             while len(individual_stack) > 0:
@@ -243,10 +251,10 @@ def parallel_eval_objective_list(individual_list,
             
             submitted_inds.add(individual.unique_id())
 
+    #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
+    # client.run(gc.collect) #run garbage collection to free up memory
 
     #collect remaining futures
-
-
     final_scores = [scores_dict[individual]["scores"] for individual in individual_list]
     final_start_times = [scores_dict[individual]["start_time"] for individual in individual_list]
     final_end_times = [scores_dict[individual]["end_time"] for individual in individual_list]

--- a/tpot2/utils/eval_utils.py
+++ b/tpot2/utils/eval_utils.py
@@ -228,7 +228,7 @@ def parallel_eval_objective_list(individual_list,
         
 
         #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-        # client.run(gc.collect) #run garbage collection to free up memory
+        client.run(gc.collect) #run garbage collection to free up memory
 
         #break if timeout
         if global_timeout_triggered:
@@ -252,7 +252,7 @@ def parallel_eval_objective_list(individual_list,
             submitted_inds.add(individual.unique_id())
 
     #I am not entirely sure if this is necessary. I believe that calling release on the futures should be enough to free up memory. If memory issues persist, this may be a good place to start.
-    # client.run(gc.collect) #run garbage collection to free up memory
+    client.run(gc.collect) #run garbage collection to free up memory
 
     #collect remaining futures
     final_scores = [scores_dict[individual]["scores"] for individual in individual_list]


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

adds a few lines of code to call future.release when we are done with a future. Also adds client.run(gc.collect) after each evaluation to clear up a potential memory leak.


## Any background context you want to provide?

I noticed that running graph pipelines with large datasets caused an issue where training effectively stopped early. TPOT did not crash, but after a number of generations, all subsequent pipelines evaluated as "INVALID". My theory is that a memory leak ate up all the available RAM, causing all subsequent pipelines to fail.

I was able to reproduce a memory leak by running graph pipelines with several polynomial transformers (as this transformation exponentially increases data size). By watching the dask dashboard, a memory leak seems to happen when a future starts using a large amount of RAM. Normally dask is able to clean the data when the pipeline is done evaluating. But in some cases with particularly large data/transformations, it is not able to free the ram. My theory is that this happens when a transformation inside the future goes beyond system memory and crashes.

I was able to free this memory by calling client.run(gc.collect) and future.release() . I added these to the parallel evaluation function in hopes that it helps TPOT to free memory more often and prevent this issue.

While I think this does help the issue, it looks like with large datasets and graph search spaces that training still sometimes terminates early in the same way as described, so there is more to look into.

Here's a short script I was able to run in a jupyter notebook that could cause a potential memory leak with dask. The unmanaged memory was able to be freed with client.run(gc.collect)

```

import numpy as np
import sklearn
import tpot2
from dask.distributed import Client
from dask.distributed import LocalCluster

cluster = LocalCluster(n_workers=3, #if no client is passed in and no global client exists, create our own
        threads_per_worker=1,
        processes=True,
        silence_logs=False,
        memory_limit="2GB")
client = Client(cluster)

from tpot2.search_spaces.nodes import *
from tpot2.search_spaces.pipelines import *

sp = GraphSearchPipeline(
    root_search_space=tpot2.config.get_search_space("DecisionTreeClassifier"),
    inner_search_space=tpot2.config.get_search_space("PolynomialFeatures"),
    max_size=7,
)

individual_list = [sp.generate() for i in range(30)]
for ind in individual_list:
    for i in range(0,np.random.randint(1,5)):
        ind.mutate()
        
individual_list[0].export_pipeline().plot()


import sklearn.datasets
import tpot2
X, y = sklearn.datasets.load_breast_cancer(return_X_y=True)

x_scatter = client.scatter(X)
y_scatter = client.scatter(y)

objective_kwargs = {"X": x_scatter, "y": y_scatter}


def my_objective_function(ind, X, y):
    pipeline = ind.export_pipeline()
    pipeline.fit(X, y)
    return pipeline.score(X, y)


objective_list = [my_objective_function]


for i in range(100):

    results = tpot2.utils.eval_utils.parallel_eval_objective_list(individual_list,
                                    objective_list,
                                    verbose=0,
                                    max_eval_time_mins=999,
                                    n_expected_columns=1,
                                    client=client,
                                    scheduled_timeout_time=None,
                                    **objective_kwargs)
```