### PR TITLE
fix bug where the wrong param was passed into columnonehotencoder

### DIFF
--- a/tpot2/tpot_estimator/estimator.py
+++ b/tpot2/tpot_estimator/estimator.py
@@ -581,7 +581,7 @@ class TPOTEstimator(BaseEstimator):
                 if self.categorical_features is not None: #if categorical features are specified, use those
                     pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnSimpleImputer(self.categorical_features, strategy='most_frequent')))
                     pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("numeric", strategy='mean')))
-                    pipeline_steps.append(("ColumnOneHotEncoder", tpot2.builtin_modules.ColumnOneHotEncoder(self.categorical_features, strategy='most_frequent')))
+                    pipeline_steps.append(("ColumnOneHotEncoder", tpot2.builtin_modules.ColumnOneHotEncoder(self.categorical_features, min_frequency=0.0001)))
 
                 else:
                     if isinstance(X, pd.DataFrame):
@@ -589,7 +589,7 @@ class TPOTEstimator(BaseEstimator):
                         if len(categorical_columns) > 0:
                             pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnSimpleImputer("categorical", strategy='most_frequent')))
                             pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("numeric", strategy='mean')))
-                            pipeline_steps.append(("ColumnOneHotEncoder", tpot2.builtin_modules.ColumnOneHotEncoder("categorical", strategy='most_frequent')))
+                            pipeline_steps.append(("ColumnOneHotEncoder", tpot2.builtin_modules.ColumnOneHotEncoder("categorical", min_frequency=0.0001)))
                         else:
                             pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("all", strategy='mean')))
                     else:

--- a/tpot2/tpot_estimator/steady_state_estimator.py
+++ b/tpot2/tpot_estimator/steady_state_estimator.py
@@ -624,7 +624,7 @@ class TPOTEstimatorSteadyState(BaseEstimator):
                 if self.categorical_features is not None: #if categorical features are specified, use those
                     pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnSimpleImputer(self.categorical_features, strategy='most_frequent')))
                     pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("numeric", strategy='mean')))
-                    pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnOneHotEncoder(self.categorical_features, strategy='most_frequent')))
+                    pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnOneHotEncoder(self.categorical_features, min_frequency=0.0001)))
 
                 else:
                     if isinstance(X, pd.DataFrame):
@@ -632,7 +632,7 @@ class TPOTEstimatorSteadyState(BaseEstimator):
                         if len(categorical_columns) > 0:
                             pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnSimpleImputer("categorical", strategy='most_frequent')))
                             pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("numeric", strategy='mean')))
-                            pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnOneHotEncoder("categorical", strategy='most_frequent')))
+                            pipeline_steps.append(("impute_categorical", tpot2.builtin_modules.ColumnOneHotEncoder("categorical", min_frequency=0.0001)))
                         else:
                             pipeline_steps.append(("impute_numeric", tpot2.builtin_modules.ColumnSimpleImputer("all", strategy='mean')))
                     else:


### PR DESCRIPTION
[please review the [Contribution Guidelines](http://epistasislab.github.io/tpot/contributing/) prior to submitting your pull request. go ahead and delete this line if you've already reviewed said guidelines.]

## What does this PR do?

Issue #163 identified a bug where the wrong parameter was being passed into ColumnOneHotEncoder when using the default fixed preprocessing steps. This removes the wrong parameter and replaces it with the original parameter before the bug was introduced.

## Where should the reviewer start?



## How should this PR be tested?

run TPOTEstimator and TPOTEsimatorSteadyState with the fixed preprocessing pipeline on pandas df that includes categorical columns. 

## Any background context you want to provide?

Issue #163

## What are the relevant issues?

Issue #163


## Questions:

- Do the docs need to be updated?
no
- Does this PR add new (Python) dependencies?
no